### PR TITLE
str_replace [altName] in ext.conf

### DIFF
--- a/cli/templates/ext.conf
+++ b/cli/templates/ext.conf
@@ -1,3 +1,3 @@
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-subjectAltName = $ENV::ALTNAME
+subjectAltName = [altName]


### PR DESCRIPTION
moving from `export ALTNAMES = $altNames` to `str_replace('[altNames]',$altNames)` for OS independence. Should work without errors on MacOSX now. Also deleted `-extension v3_req` param from openssl command, because it's not needed for local-development (Seems its declared in ext.conf).